### PR TITLE
Rank results by relevance and popularity instead of date

### DIFF
--- a/src/main/kotlin/com/antodippo/ccmusicsearch/RelevanceRanker.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/RelevanceRanker.kt
@@ -1,0 +1,71 @@
+package com.antodippo.ccmusicsearch
+
+/**
+ * Merges the per-service result lists into one ranking.
+ *
+ * Every service hands back a list already ordered by its own notion of relevance, but
+ * those scores live on incomparable scales — a Jamendo relevance score means nothing
+ * next to a Solr score from the Internet Archive. So we fuse on position alone
+ * (Reciprocal Rank Fusion): each result contributes 1 / (K + rank), no normalisation
+ * required.
+ *
+ * Each service supplies two orderings — the relevance order it returned, and the same
+ * results re-sorted by popularity. Services that expose no popularity signal reuse
+ * their relevance order for both, which keeps them on the same scale as everyone else
+ * rather than quietly penalising them.
+ *
+ * The catalogues barely overlap today, so in practice this behaves as a weighted
+ * interleave rather than true consensus fusion. It turns into the latter for free as
+ * soon as two services index the same track.
+ */
+object RelevanceRanker {
+
+    private const val K = 60.0
+    private const val RELEVANCE_WEIGHT = 1.0
+    private const val POPULARITY_WEIGHT = 0.5
+
+    // Freesound is a sample library. Even filtered to a minimum duration it contributes
+    // loops and one-shots, so it gets to compete for fewer of the top slots.
+    private val serviceWeights = mapOf(SearchService.FREESOUND to 0.5)
+
+    fun rank(resultsByService: List<Collection<SearchResult>>): List<SearchResult> =
+        resultsByService
+            .flatMap { scoreOneService(it.toList()) }
+            .sortedByDescending { (_, score) -> score }
+            .map { (result, _) -> result }
+
+    private fun scoreOneService(results: List<SearchResult>): List<Pair<SearchResult, Double>> {
+        if (results.isEmpty()) {
+            return emptyList()
+        }
+
+        val weight = serviceWeights[results.first().service] ?: 1.0
+        val popularityRanks = popularityRanks(results)
+
+        return results.mapIndexed { index, result ->
+            val relevanceRank = index + 1
+            val popularityRank = popularityRanks?.get(index) ?: relevanceRank
+
+            result to weight * (
+                RELEVANCE_WEIGHT / (K + relevanceRank) + POPULARITY_WEIGHT / (K + popularityRank)
+            )
+        }
+    }
+
+    /**
+     * Position of each result once sorted by popularity, indexed the same way as the
+     * input. Null when the service exposes no popularity signal at all.
+     */
+    private fun popularityRanks(results: List<SearchResult>): IntArray? {
+        if (results.none { it.popularity != null }) {
+            return null
+        }
+
+        val ranks = IntArray(results.size)
+        results.indices
+            .sortedByDescending { results[it].popularity ?: -1 }
+            .forEachIndexed { rank, index -> ranks[index] = rank + 1 }
+
+        return ranks
+    }
+}

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/SearchEngine.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/SearchEngine.kt
@@ -13,13 +13,10 @@ class SearchEngine(
 ) {
 
     suspend fun search(query: String): List<SearchResult> = coroutineScope {
-        val results = mutableListOf<SearchResult>()
-        searchServices.map {
-            async {
-                results.addAll(it.search(query))
-            }
-        }.awaitAll()
+        val resultsByService = searchServices
+            .map { async { it.search(query) } }
+            .awaitAll()
 
-        return@coroutineScope results.sortedByDescending { it.date }
+        return@coroutineScope RelevanceRanker.rank(resultsByService)
     }
 }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/SearchResult.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/SearchResult.kt
@@ -16,6 +16,9 @@ data class SearchResult(
     val licenseUrl: URI = license.toLicenseUrl(),
     val licenseLogoUrl: URI = license.toLicenseLogoUrl(),
     val service: SearchService,
+    // Whatever the service uses to say "people came back to this one": plays, downloads,
+    // ratings. Only comparable within a single service, never across them.
+    val popularity: Long? = null,
 )
 
 enum class SearchService {

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/CCMixter.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/CCMixter.kt
@@ -8,7 +8,6 @@ import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.net.URI
 import java.net.URLEncoder
-import java.net.http.HttpResponse
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 import java.util.*
@@ -19,16 +18,22 @@ class CCMixter(private val apiClient: APIClient): APIService {
         val logger = KotlinLogging.logger {}
         val escapedQuery = URLEncoder.encode(query, "UTF-8")
 
-        val response : HttpResponse<String>
+        val jsonBody: JsonNode
         try {
             // TODO Solve problem with handshaking :(
-            response = apiClient.get(URI("https://ccmixter.org/api/query?limit=20&f=json&tags=$escapedQuery"))
+            // search= rather than tags=: it matches title and artist as well as tags, so
+            // "jazz" finds "Jazzy Parts", which a tag-only query misses. No sort parameter,
+            // which leaves ccMixter's own relevance order in place.
+            // 25 is the ceiling — ask for more and ccMixter answers 200 with an empty body.
+            val response = apiClient.get(URI("https://ccmixter.org/api/query?limit=25&f=json&search=$escapedQuery"))
+            // Parsed inside the try: an empty body is a real response from this API, and
+            // letting it throw here would take down every other service's results too.
+            jsonBody = jacksonObjectMapper().readValue(response.body())
         } catch (e: Exception) {
             logger.error { "Error while searching on CCMixter: ${e.message}" }
             return emptyList()
         }
 
-        val jsonBody = jacksonObjectMapper().readValue<JsonNode>(response.body())
         if (!jsonBody.isEmpty) {
             return jsonBody.map {
                 SearchResult(
@@ -43,7 +48,8 @@ class CCMixter(private val apiClient: APIClient): APIService {
                     ),
                     externalLink = URI.create(it["file_page_url"]?.asText().toString()),
                     license = CCLicense.fromUrl(it["license_url"].asText()),
-                    service = SearchService.CCMIXTER
+                    service = SearchService.CCMIXTER,
+                    popularity = it["upload_num_scores"]?.asLong()
                 )
             }
         }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/Freesound.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/Freesound.kt
@@ -23,12 +23,17 @@ class Freesound(private val apiClient: APIClient) : APIService {
         val response: HttpResponse<String>
         val tracksArray: JsonNode?
         try {
-            val fields = "id,name,username,tags,duration,created,url,license"
-            response = apiClient.get(URI("https://freesound.org/apiv2/search/text/?token=$apiKey&query=$escapedQuery&sort=created_desc&fields=$fields&page_size=5"))
+            val fields = "id,name,username,tags,duration,created,url,license,num_downloads"
+            // sort=score is Freesound's relevance order. The duration floor is the only
+            // lever that separates pieces of music from the one-shots and loops that make
+            // up most of the library — it stays a sample site, so RelevanceRanker also
+            // weights it below the music services.
+            val filter = URLEncoder.encode("duration:[60 TO *]", "UTF-8")
+            response = apiClient.get(URI("https://freesound.org/apiv2/search/text/?token=$apiKey&query=$escapedQuery&sort=score&filter=$filter&fields=$fields&page_size=50"))
             val jsonBody = jacksonObjectMapper().readValue<JsonNode>(response.body())
             tracksArray = jsonBody["results"]
         } catch (e: Exception) {
-            logger.error { "Error while searching on Internet Archive: ${e.message}" }
+            logger.error { "Error while searching on Freesound: ${e.message}" }
             return emptyList()
         }
 
@@ -43,7 +48,8 @@ class Freesound(private val apiClient: APIClient) : APIService {
                     date = LocalDate.parse(it["created"].asText().substringBefore("T")),
                     externalLink = URI.create(it["url"].asText()),
                     license = CCLicense.fromUrl(it["license"].asText()),
-                    service = SearchService.FREESOUND
+                    service = SearchService.FREESOUND,
+                    popularity = it["num_downloads"]?.asLong()
                 )
             }
         }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchive.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchive.kt
@@ -15,14 +15,32 @@ import java.time.format.DateTimeFormatter
 @Service
 class InternetArchive(private val apiClient: APIClient) : APIService {
 
+    // The archive is mostly not music: lectures, radio shows, podcasts and live sets all
+    // live under mediatype:audio. audio_music and netlabels are the two collections that
+    // hold released music, and licenseurl:(*http*) drops the "taper permitted" live
+    // recordings, which are freely shared but not Creative Commons.
+    private val musicOnly =
+        "mediatype:(audio) AND collection:(audio_music OR netlabels) AND licenseurl:(*http*)"
+
+    private val fields = listOf(
+        "identifier", "title", "creator", "subject",
+        "licenseurl", "publicdate", "downloads", "mediatype"
+    )
+
     override suspend fun search(query: String): List<SearchResult> {
         val logger = KotlinLogging.logger {}
-        val escapedQuery = URLEncoder.encode(query, "UTF-8")
+        val escapedQuery = URLEncoder.encode("$query AND $musicOnly", "UTF-8")
+        val fieldParams = fields.joinToString("") { "&fl%5B%5D=$it" }
 
         val response: HttpResponse<String>
         val tracksArray: JsonNode?
         try {
-            response = apiClient.get(URI("https://archive.org/advancedsearch.php?q=subject:$escapedQuery&rows=20&output=json&mediatype=audio&sort=createdate+desc"))
+            // No sort parameter: the archive defaults to relevance, which is what we want.
+            // mediatype has to be part of q — passing it as its own parameter is rejected
+            // with [UNSUPPORTED_VALUE] and there is no "response" key to read back.
+            response = apiClient.get(
+                URI("https://archive.org/advancedsearch.php?q=$escapedQuery&rows=50&output=json$fieldParams")
+            )
             val jsonBody = jacksonObjectMapper().readValue<JsonNode>(response.body())
             tracksArray = jsonBody["response"]["docs"]
         } catch (e: Exception) {
@@ -32,7 +50,7 @@ class InternetArchive(private val apiClient: APIClient) : APIService {
 
         if (tracksArray != null && tracksArray.isArray) {
             return tracksArray
-                .filter { it["mediatype"].asText() == "audio" }
+                .filter { it["mediatype"]?.asText() == "audio" }
                 .map {
                     SearchResult(
                         author = it["creator"]?.asText() ?: "",
@@ -44,9 +62,10 @@ class InternetArchive(private val apiClient: APIClient) : APIService {
                             it["publicdate"].asText(),
                             DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
                         ),
-                        externalLink = URI.create("https://archive.org/search?query=${it["identifier"].asText()}"),
+                        externalLink = URI.create("https://archive.org/details/${it["identifier"].asText()}"),
                         license = CCLicense.fromUrl(it["licenseurl"]?.asText() ?: ""),
-                        service = SearchService.INTERNETARCHIVE
+                        service = SearchService.INTERNETARCHIVE,
+                        popularity = it["downloads"]?.asLong()
                     )
             }
         }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/Jamendo.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/Jamendo.kt
@@ -8,7 +8,6 @@ import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import java.net.URI
 import java.net.URLEncoder
-import java.net.http.HttpResponse
 import java.time.LocalDate
 
 @Service
@@ -19,15 +18,20 @@ class Jamendo(private val apiClient: APIClient) : APIService {
         val apiKey = System.getProperty("JAMENDO_API_KEY")
         val escapedQuery = URLEncoder.encode(query, "UTF-8")
 
-        val response : HttpResponse<String>
+        val jsonBody: JsonNode
         try {
-            response = apiClient.get(URI("https://api.jamendo.com/v3.0/tracks/?client_id=$apiKey&format=jsonpretty&order=releasedate_desc&limit=20&search=$escapedQuery"))
+            // durationbetween keeps out the stingers and idents at one end and the
+            // hour-long DJ sets at the other. Jamendo's default response carries no
+            // popularity counter; include=stats would add one if we ever want it.
+            val response = apiClient.get(URI("https://api.jamendo.com/v3.0/tracks/?client_id=$apiKey&format=jsonpretty&order=relevance&limit=50&durationbetween=60_600&search=$escapedQuery"))
+            // Parsed inside the try so a malformed or empty body costs us Jamendo's results
+            // rather than every service's.
+            jsonBody = jacksonObjectMapper().readValue(response.body())
         } catch (e: Exception) {
             logger.error { "Error while searching on Jamendo: ${e.message}" }
             return emptyList()
         }
 
-        val jsonBody = jacksonObjectMapper().readValue<JsonNode>(response.body())
         if (!jsonBody.isEmpty && jsonBody["results"] != null) {
             return jsonBody["results"].map {
                 SearchResult(

--- a/src/main/resources/templates/search.mustache
+++ b/src/main/resources/templates/search.mustache
@@ -138,7 +138,9 @@
         $('#dataTable').DataTable({
             paging: true,
             pageLength: 25,
-            order: [[5, 'desc']]
+            // Empty on purpose: the server already ordered these by relevance, and any
+            // column sort here would throw that away.
+            order: []
         });
 
         // Search functionality

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/RelevanceRankerTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/RelevanceRankerTest.kt
@@ -1,0 +1,135 @@
+package com.antodippo.ccmusicsearch
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.net.URI
+import java.time.LocalDate
+
+class RelevanceRankerTest {
+
+    private fun result(
+        title: String,
+        service: SearchService,
+        date: String = "2020-01-01",
+        popularity: Long? = null
+    ) = SearchResult(
+        author = "author",
+        title = title,
+        duration = 120,
+        bpm = 0,
+        tags = "",
+        date = LocalDate.parse(date),
+        externalLink = URI.create("https://example.org/$title"),
+        license = CCLicense.CC_BY,
+        service = service,
+        popularity = popularity
+    )
+
+    private fun titles(results: List<SearchResult>) = results.map { it.title }
+
+    @Test
+    fun testItInterleavesServicesInsteadOfConcatenatingThem() {
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(result("jam1", SearchService.JAMENDO), result("jam2", SearchService.JAMENDO)),
+                listOf(result("mix1", SearchService.CCMIXTER), result("mix2", SearchService.CCMIXTER))
+            )
+        )
+
+        // Neither service reports popularity here, so equal ranks score equally and the
+        // stable sort keeps them in service order.
+        assertEquals(listOf("jam1", "mix1", "jam2", "mix2"), titles(ranked))
+    }
+
+    @Test
+    fun testItIgnoresDateEntirely() {
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(
+                    result("mostRelevantButOldest", SearchService.JAMENDO, date = "1999-01-01"),
+                    result("lessRelevantButNewest", SearchService.JAMENDO, date = "2026-01-01")
+                )
+            )
+        )
+
+        assertEquals(listOf("mostRelevantButOldest", "lessRelevantButNewest"), titles(ranked))
+    }
+
+    @Test
+    fun testPopularityLiftsAResultTheServiceRankedLower() {
+        // The archive's second hit is also its most downloaded, while its top hit is its
+        // least. That is a five-place popularity gap against a one-place relevance gap, so
+        // the second hit takes the lead.
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(
+                    result("topHitButIgnored", SearchService.INTERNETARCHIVE, popularity = 1),
+                    result("secondButBeloved", SearchService.INTERNETARCHIVE, popularity = 1000),
+                    result("third", SearchService.INTERNETARCHIVE, popularity = 500),
+                    result("fourth", SearchService.INTERNETARCHIVE, popularity = 400),
+                    result("fifth", SearchService.INTERNETARCHIVE, popularity = 300),
+                    result("sixth", SearchService.INTERNETARCHIVE, popularity = 200)
+                )
+            )
+        )
+
+        assertEquals(
+            listOf("secondButBeloved", "topHitButIgnored", "third", "fourth", "fifth", "sixth"),
+            titles(ranked)
+        )
+    }
+
+    @Test
+    fun testRelevanceStillOutweighsPopularityOverASingleRank() {
+        // Popularity nudges, it does not take over: one place of relevance is worth more
+        // than one place of popularity, however lopsided the download counts are.
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(
+                    result("barelyPlayed", SearchService.INTERNETARCHIVE, popularity = 1),
+                    result("aClassic", SearchService.INTERNETARCHIVE, popularity = 99999)
+                )
+            )
+        )
+
+        assertEquals(listOf("barelyPlayed", "aClassic"), titles(ranked))
+    }
+
+    @Test
+    fun testAServiceWithoutPopularityKeepsItsOwnOrder() {
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(
+                    result("first", SearchService.JAMENDO),
+                    result("second", SearchService.JAMENDO),
+                    result("third", SearchService.JAMENDO)
+                )
+            )
+        )
+
+        assertEquals(listOf("first", "second", "third"), titles(ranked))
+    }
+
+    @Test
+    fun testFreesoundIsWeightedBelowTheMusicServices() {
+        // Both are their service's top hit, so only the service weight separates them.
+        val ranked = RelevanceRanker.rank(
+            listOf(
+                listOf(result("sample", SearchService.FREESOUND)),
+                listOf(result("song", SearchService.JAMENDO))
+            )
+        )
+
+        assertEquals(listOf("song", "sample"), titles(ranked))
+    }
+
+    @Test
+    fun testItHandlesEmptyAndMissingServices() {
+        val ranked = RelevanceRanker.rank(
+            listOf(emptyList(), listOf(result("only", SearchService.JAMENDO)), emptyList())
+        )
+
+        assertEquals(listOf("only"), titles(ranked))
+        assertEquals(emptyList<SearchResult>(), RelevanceRanker.rank(emptyList()))
+    }
+}

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/SearchEngineTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/SearchEngineTest.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 class SearchEngineTest {
 
     @Test
-    fun testSearchServicesAreCalledAndResultsAreMerged() = runBlocking {
+    fun testSearchServicesAreCalledAndResultsAreMergedByRelevance() = runBlocking {
         val searchEngine = SearchEngine(
             listOf(
                 Jamendo(ApiClientThatReadsFromFile("jamendo")),
@@ -24,6 +24,8 @@ class SearchEngineTest {
 
         val results = searchEngine.search("test")
 
+        // Services are interleaved by fused rank rather than concatenated, and no longer
+        // ordered by date — the oldest of the four (2014-06-27) sits third.
         val expectedResults = listOf(
             SearchResult(
                 author = "Arnold Wohler",
@@ -37,17 +39,6 @@ class SearchEngineTest {
                 service = SearchService.JAMENDO
             ),
             SearchResult(
-                author = "Agnes",
-                title = "Znajdź swój blask",
-                duration = 195,
-                bpm = 0,
-                tags = "",
-                date = LocalDate.parse("2020-05-01"),
-                externalLink = URI.create("https://www.jamendo.com/track/1759840"),
-                license = CCLicense.CC_BY_NC_ND,
-                service = SearchService.JAMENDO
-            ),
-            SearchResult(
                 author = "Reiswerk",
                 title = "Luwan House feat Sonja V",
                 duration = 148,
@@ -56,7 +47,8 @@ class SearchEngineTest {
                 date = LocalDate.parse("2014-07-01"),
                 externalLink = URI.create("http://ccmixter.org/files/Reiswerk/46456"),
                 license = CCLicense.CC_BY_NC,
-                service = SearchService.CCMIXTER
+                service = SearchService.CCMIXTER,
+                popularity = 6
             ),
             SearchResult(
                 author = "JeffSpeed68",
@@ -67,7 +59,19 @@ class SearchEngineTest {
                 date = LocalDate.parse("2014-06-27"),
                 externalLink = URI.create("http://ccmixter.org/files/JeffSpeed68/46416"),
                 license = CCLicense.CC_BY,
-                service = SearchService.CCMIXTER
+                service = SearchService.CCMIXTER,
+                popularity = 9
+            ),
+            SearchResult(
+                author = "Agnes",
+                title = "Znajdź swój blask",
+                duration = 195,
+                bpm = 0,
+                tags = "",
+                date = LocalDate.parse("2020-05-01"),
+                externalLink = URI.create("https://www.jamendo.com/track/1759840"),
+                license = CCLicense.CC_BY_NC_ND,
+                service = SearchService.JAMENDO
             )
         )
 

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/CCMixterTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/CCMixterTest.kt
@@ -4,6 +4,7 @@ import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReadsFromFile
 import com.antodippo.ccmusicsearch.CCLicense
 import com.antodippo.ccmusicsearch.SearchResult
 import com.antodippo.ccmusicsearch.SearchService
+import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReturnsAnEmptyBody
 import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatThrows
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
@@ -30,7 +31,8 @@ class CCMixterTest {
                 date = LocalDate.parse("2014-07-01"),
                 externalLink = URI.create("http://ccmixter.org/files/Reiswerk/46456"),
                 license = CCLicense.CC_BY_NC,
-                service = SearchService.CCMIXTER
+                service = SearchService.CCMIXTER,
+                popularity = 6
             ),
             SearchResult(
                 author = "JeffSpeed68",
@@ -41,7 +43,8 @@ class CCMixterTest {
                 date = LocalDate.parse("2014-06-27"),
                 externalLink = URI.create("http://ccmixter.org/files/JeffSpeed68/46416"),
                 license = CCLicense.CC_BY,
-                service = SearchService.CCMIXTER
+                service = SearchService.CCMIXTER,
+                popularity = 9
             )
         )
 
@@ -58,7 +61,15 @@ class CCMixterTest {
 
     @Test
     fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyJson() = runBlocking {
-        val ccMixter = CCMixter(ApiClientThatReadsFromFile("empty"))
+        val ccMixter = CCMixter(ApiClientThatReadsFromFile("emptyresponse"))
+        val results = ccMixter.search("test")
+
+        assertEquals(emptyList<SearchResult>(), results)
+    }
+
+    @Test
+    fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyBody() = runBlocking {
+        val ccMixter = CCMixter(ApiClientThatReturnsAnEmptyBody())
         val results = ccMixter.search("test")
 
         assertEquals(emptyList<SearchResult>(), results)

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/FreesoundTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/FreesoundTest.kt
@@ -4,6 +4,7 @@ import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReadsFromFile
 import com.antodippo.ccmusicsearch.CCLicense
 import com.antodippo.ccmusicsearch.SearchResult
 import com.antodippo.ccmusicsearch.SearchService
+import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReturnsAnEmptyBody
 import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatThrows
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
@@ -64,4 +65,12 @@ class FreesoundTest {
         assertEquals(emptyList<SearchResult>(), results)
     }
 
+
+    @Test
+    fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyBody() = runBlocking {
+        val freesound = Freesound(ApiClientThatReturnsAnEmptyBody())
+        val results = freesound.search("test")
+
+        assertEquals(emptyList<SearchResult>(), results)
+    }
 }

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchiveTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchiveTest.kt
@@ -4,6 +4,7 @@ import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReadsFromFile
 import com.antodippo.ccmusicsearch.CCLicense
 import com.antodippo.ccmusicsearch.SearchResult
 import com.antodippo.ccmusicsearch.SearchService
+import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReturnsAnEmptyBody
 import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatThrows
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
@@ -28,9 +29,10 @@ class InternetArchiveTest {
                 bpm = 0,
                 tags = "\"drone\", \"psychedelic\", \"folk\"",
                 date = LocalDate.parse("2016-07-14"),
-                externalLink = URI.create("https://archive.org/search?query=NaturalSnowBuildings-Aldebaran2016"),
+                externalLink = URI.create("https://archive.org/details/NaturalSnowBuildings-Aldebaran2016"),
                 license = CCLicense.CC_BY_NC_ND,
-                service = SearchService.INTERNETARCHIVE
+                service = SearchService.INTERNETARCHIVE,
+                popularity = 2300
             ),
             SearchResult(
                 author = "El Chata de Vicalvaro",
@@ -39,9 +41,10 @@ class InternetArchiveTest {
                 bpm = 0,
                 tags = "\"78rpm\", \"Folk\"",
                 date = LocalDate.parse("2018-04-26"),
-                externalLink = URI.create("https://archive.org/search?query=78_cante-de-levante-amores-no-ha-de-buscar"),
+                externalLink = URI.create("https://archive.org/details/78_cante-de-levante-amores-no-ha-de-buscar"),
                 license = CCLicense.UNKNOWN,
-                service = SearchService.INTERNETARCHIVE
+                service = SearchService.INTERNETARCHIVE,
+                popularity = 500
             )
         )
 
@@ -59,6 +62,14 @@ class InternetArchiveTest {
     @Test
     fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyJson() = runBlocking {
         val internetArchive = InternetArchive(ApiClientThatReadsFromFile("emptyresponse"))
+        val results = internetArchive.search("test")
+
+        assertEquals(emptyList<SearchResult>(), results)
+    }
+
+    @Test
+    fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyBody() = runBlocking {
+        val internetArchive = InternetArchive(ApiClientThatReturnsAnEmptyBody())
         val results = internetArchive.search("test")
 
         assertEquals(emptyList<SearchResult>(), results)

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/JamendoTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/JamendoTest.kt
@@ -4,6 +4,7 @@ import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReadsFromFile
 import com.antodippo.ccmusicsearch.CCLicense
 import com.antodippo.ccmusicsearch.SearchResult
 import com.antodippo.ccmusicsearch.SearchService
+import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReturnsAnEmptyBody
 import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatThrows
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.*
@@ -59,6 +60,14 @@ class JamendoTest {
     @Test
     fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyJson() = runBlocking {
         val jamendo = Jamendo(ApiClientThatReadsFromFile("emptyresponse"))
+        val results = jamendo.search("test")
+
+        assertEquals(emptyList<SearchResult>(), results)
+    }
+
+    @Test
+    fun testItReturnsAnEmptyListWhenTheClientReturnsAnEmptyBody() = runBlocking {
+        val jamendo = Jamendo(ApiClientThatReturnsAnEmptyBody())
         val results = jamendo.search("test")
 
         assertEquals(emptyList<SearchResult>(), results)

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/testdoubles/ApiClientThatReturnsAnEmptyBody.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/testdoubles/ApiClientThatReturnsAnEmptyBody.kt
@@ -1,0 +1,15 @@
+package com.antodippo.ccmusicsearch.testdoubles
+
+import com.antodippo.ccmusicsearch.APIClient
+import java.net.URI
+import java.net.http.HttpResponse
+
+/**
+ * Answers 200 with nothing in it, the way ccMixter does when a query asks for more
+ * results than it is willing to return.
+ */
+class ApiClientThatReturnsAnEmptyBody : APIClient {
+    override suspend fun get(uri: URI): HttpResponse<String> {
+        return HttpDummyResponse(200, "")
+    }
+}


### PR DESCRIPTION
Results were fetched newest-first and sorted by creation date. For a search engine meant to serve radios and projects looking for usable music, "most recently uploaded" is the wrong answer — this switches to relevance, blended with each service's own popularity signal.

While measuring the current behaviour I found two of the five services returning nothing in production, which mattered more than the ranking itself.

## Internet Archive returned zero results on every query

It passed `mediatype=audio` as a top-level parameter. The API rejects that:

```
{"error":"[UNSUPPORTED_VALUE] A requested parameter has an inappropriate value audio for request parameter mediatype"}
```

The error payload has no `response` key, so `jsonBody["response"]["docs"]` threw and the catch-all turned it into an empty list. Confirmed against production — `curl "https://ccmusicsearch.com/?q=jazz"` returned 45 rows: ccmixter 20, jamendo 20, freesound 5, **internetarchive 0, icons8 0**.

`mediatype` now goes inside `q`, together with collection and licence filters that keep out the lectures, radio shows and non-CC live recordings that dominate `mediatype:audio`. The query also no longer restricts matching to `subject:`, so titles and creators match too, and the "Listen" link points at the item page instead of a search URL.

## The ranking

New `RelevanceRanker` using Reciprocal Rank Fusion:

```
score = weight_service × ( 1.0 / (60 + relevanceRank) + 0.5 / (60 + popularityRank) )
```

The APIs' internal scores are on incomparable scales, so fusion is on position only and needs no normalisation. Each service contributes two orderings — the relevance order it returned, and that same set re-sorted by popularity (ccMixter's `upload_num_scores`, the archive's `downloads`, Freesound's `num_downloads`). Services with no popularity signal reuse their relevance order, which keeps them on the same scale rather than penalising them.

Relevance outweighs popularity 2:1, so popularity can't overturn a one-place relevance gap — only a larger one. There's a test pinning each direction.

Worth knowing: the catalogues barely overlap, so today this behaves as a weighted interleave rather than true consensus fusion. It becomes real fusion for free as soon as two services index the same track.

## Music, not samples

| Service | Relevance | Music-only |
|---|---|---|
| Jamendo | `order=relevance`, `limit=50` | `durationbetween=60_600` |
| ccMixter | `search=` not `tags=`, `limit=25` | already music |
| Internet Archive | no `sort` (defaults to relevance), `rows=50` | `mediatype:(audio) AND collection:(audio_music OR netlabels) AND licenseurl:(*http*)` |
| Freesound | `sort=score`, `page_size=50` | `filter=duration:[60 TO *]` |

Freesound is a sample library by design and will contribute loops even filtered, so it also carries a 0.5 service weight in the ranker.

## Two things that would have silently undone this

`search.mustache` had `order: [[5, 'desc']]` — column 5 is Date. DataTables re-sorted the page client-side, so any server-side ranking was discarded before rendering. Now `order: []`.

Jamendo and CCMixter parsed the response body *outside* the try/catch. Because `SearchEngine` uses `coroutineScope`, a throw there took down every other service's results too. This is not hypothetical: ccMixter answers **200 with an empty body** for any `limit` above 25, which is why it's capped there. Both now parse inside the try, with a regression test per service.

## Verification

Running locally against the live APIs, `?q=jazz` returns **75 results** (ccMixter 25 + Internet Archive 50, up from 45 with the archive contributing nothing). Services interleave throughout and the page is no longer date-ordered — a 2010 track sits at #3, a 2026 one at #8. The top hit is "Jazzy Parts", the exact track `tags=jazz` used to miss.

Popularity is doing visible work: the archive's relevance-#1 had 31 downloads and fell to #10, while tracks with 1242 / 7602 / 9483 downloads rose into the top four.

All 27 tests pass.

## For the reviewer

- **Jamendo, Freesound and Icons8 were not exercised against their live APIs** — no keys available locally. Their query changes come from the published parameter docs and are unit-tested against fixtures. Worth a look once deployed.
- **Icons8 returns `{"error":"401 Unauthorized"}`.** The endpoint is alive, so it's the key, but I couldn't tell whether the deployed one expired or the plan changed. Left untouched. Separately, it hardcodes `CCLicense.UNKNOWN` because Icons8 music isn't Creative Commons — worth deciding whether it belongs here.
- **The ranker constants are defensible defaults, not tuned** against a relevance judgment set. `K`, the two weights and the per-service weights are the knobs.
- Fixed a pre-existing test bug: `CCMixterTest` referenced a fixture named `empty` that doesn't exist, so it passed because the file read threw rather than because it tested empty JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)