### PR TITLE
Stop one missing metadata field from failing every search

### DIFF
--- a/src/main/kotlin/com/antodippo/ccmusicsearch/SearchEngine.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/SearchEngine.kt
@@ -1,9 +1,11 @@
 package com.antodippo.ccmusicsearch
 
 import com.antodippo.ccmusicsearch.apiservices.APIService
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import mu.KotlinLogging
 import org.springframework.stereotype.Service
 
 
@@ -12,11 +14,30 @@ class SearchEngine(
     private val searchServices: List<APIService> = SearchService.values().map { it.toService() },
 ) {
 
+    private val logger = KotlinLogging.logger {}
+
     suspend fun search(query: String): List<SearchResult> = coroutineScope {
         val resultsByService = searchServices
-            .map { async { it.search(query) } }
+            .map { service -> async { searchOne(service, query) } }
             .awaitAll()
 
         return@coroutineScope RelevanceRanker.rank(resultsByService)
     }
+
+    /**
+     * A search is worth running for whichever services answer. Each of them already
+     * catches its own transport and parsing failures; this is the backstop for anything
+     * that gets past that, which under coroutineScope would otherwise cancel the other
+     * services and fail the request outright.
+     */
+    private suspend fun searchOne(service: APIService, query: String): Collection<SearchResult> =
+        try {
+            service.search(query)
+        } catch (e: CancellationException) {
+            // Not a service failure — the scope is being torn down and must stay torn down.
+            throw e
+        } catch (e: Exception) {
+            logger.error(e) { "Search failed on ${service.javaClass.simpleName}, continuing without it" }
+            emptyList()
+        }
 }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchive.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchive.kt
@@ -10,10 +10,11 @@ import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpResponse
 import java.time.LocalDate
-import java.time.format.DateTimeFormatter
 
 @Service
 class InternetArchive(private val apiClient: APIClient) : APIService {
+
+    private val logger = KotlinLogging.logger {}
 
     // The archive is mostly not music: lectures, radio shows, podcasts and live sets all
     // live under mediatype:audio. audio_music and netlabels are the two collections that
@@ -28,7 +29,6 @@ class InternetArchive(private val apiClient: APIClient) : APIService {
     )
 
     override suspend fun search(query: String): List<SearchResult> {
-        val logger = KotlinLogging.logger {}
         val escapedQuery = URLEncoder.encode("$query AND $musicOnly", "UTF-8")
         val fieldParams = fields.joinToString("") { "&fl%5B%5D=$it" }
 
@@ -51,25 +51,54 @@ class InternetArchive(private val apiClient: APIClient) : APIService {
         if (tracksArray != null && tracksArray.isArray) {
             return tracksArray
                 .filter { it["mediatype"]?.asText() == "audio" }
-                .map {
-                    SearchResult(
-                        author = it["creator"]?.asText() ?: "",
-                        title = it["title"]?.asText() ?: "",
-                        duration = 0,
-                        bpm = 0,
-                        tags = it["subject"].take(7).joinToString(", ").take(70),
-                        date = LocalDate.parse(
-                            it["publicdate"].asText(),
-                            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
-                        ),
-                        externalLink = URI.create("https://archive.org/details/${it["identifier"].asText()}"),
-                        license = CCLicense.fromUrl(it["licenseurl"]?.asText() ?: ""),
-                        service = SearchService.INTERNETARCHIVE,
-                        popularity = it["downloads"]?.asLong()
-                    )
-            }
+                .mapNotNull { toSearchResult(it) }
         }
 
         return emptyList()
+    }
+
+    /**
+     * Null when the item cannot be turned into a result at all.
+     *
+     * The archive's metadata is filled in by whoever uploaded the item, so every field
+     * here is optional in practice however standard it looks: roughly one item in fifty
+     * carries no subject, and a few percent give subject as a bare string rather than a
+     * list. Anything unusable costs us that one item — never the response, and never
+     * the other services, which is what happens if this throws inside SearchEngine's
+     * coroutineScope.
+     */
+    private fun toSearchResult(doc: JsonNode): SearchResult? {
+        // The only two without a sensible stand-in: there is nothing to link to without
+        // an identifier, and SearchResult.date is not nullable.
+        val identifier = doc["identifier"]?.asText() ?: return null
+        val publicDate = doc["publicdate"]?.asText() ?: return null
+
+        return try {
+            SearchResult(
+                author = doc["creator"]?.asText() ?: "",
+                title = doc["title"]?.asText() ?: "",
+                duration = 0,
+                bpm = 0,
+                tags = tags(doc["subject"]),
+                // Always yyyy-MM-ddTHH:mm:ssZ today, but cutting at the T keeps a change
+                // of precision at the other end from costing us the item.
+                date = LocalDate.parse(publicDate.substringBefore("T")),
+                externalLink = URI.create("https://archive.org/details/$identifier"),
+                license = CCLicense.fromUrl(doc["licenseurl"]?.asText() ?: ""),
+                service = SearchService.INTERNETARCHIVE,
+                popularity = doc["downloads"]?.asLong()
+            )
+        } catch (e: Exception) {
+            logger.warn { "Skipping Internet Archive item $identifier: ${e.message}" }
+            null
+        }
+    }
+
+    private fun tags(subject: JsonNode?): String = when {
+        subject == null -> ""
+        // Uploaders who typed their subjects into one field instead of several. Without
+        // this they iterate as a node with no children and the item shows no tags.
+        subject.isTextual -> subject.asText().take(70)
+        else -> subject.take(7).joinToString(", ").take(70)
     }
 }

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/SearchEngineTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/SearchEngineTest.kt
@@ -1,10 +1,12 @@
 package com.antodippo.ccmusicsearch
 
+import com.antodippo.ccmusicsearch.apiservices.APIService
 import com.antodippo.ccmusicsearch.apiservices.CCMixter
 import com.antodippo.ccmusicsearch.apiservices.Jamendo
 import com.antodippo.ccmusicsearch.testdoubles.ApiClientThatReadsFromFile
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
 import java.net.URI
@@ -76,6 +78,27 @@ class SearchEngineTest {
         )
 
         assertEquals(expectedResults, results)
+    }
+
+    @Test
+    fun testOneServiceFailingDoesNotTakeDownTheRestOfTheSearch() = runBlocking {
+        val searchEngine = SearchEngine(
+            listOf(
+                ServiceThatThrows(),
+                Jamendo(ApiClientThatReadsFromFile("jamendo"))
+            )
+        )
+
+        val results = searchEngine.search("test")
+
+        assertEquals(2, results.size)
+        assertTrue(results.all { it.service == SearchService.JAMENDO })
+    }
+
+    private class ServiceThatThrows : APIService {
+        override suspend fun search(query: String): Collection<SearchResult> {
+            throw NullPointerException("get(...) must not be null")
+        }
     }
 
 }

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiresponses/internetarchivewithoddmetadata.json
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiresponses/internetarchivewithoddmetadata.json
@@ -1,0 +1,74 @@
+{
+  "responseHeader": {
+    "status": 0,
+    "QTime": 61,
+    "params": {
+      "query": "jazz AND mediatype:(audio) AND collection:(audio_music OR netlabels) AND licenseurl:(*http*)",
+      "fields": "identifier,title,creator,subject,licenseurl,publicdate,downloads,mediatype",
+      "wt": "json",
+      "rows": "5",
+      "start": 0
+    }
+  },
+  "response": {
+    "numFound": 42950,
+    "start": 0,
+    "docs": [
+      {
+        "creator": "Natural Snow Buildings",
+        "downloads": 2300,
+        "identifier": "NaturalSnowBuildings-Aldebaran2016",
+        "licenseurl": "http://creativecommons.org/licenses/by-nc-nd/4.0/",
+        "mediatype": "audio",
+        "publicdate": "2016-07-14T09:41:52Z",
+        "subject": [
+          "drone",
+          "psychedelic",
+          "folk"
+        ],
+        "title": "Aldebaran [2016]"
+      },
+      {
+        "creator": "Aleksi Eeben",
+        "downloads": 6690,
+        "identifier": "mtk201",
+        "licenseurl": "http://creativecommons.org/licenses/by-nc-nd/3.0/us/",
+        "mediatype": "audio",
+        "publicdate": "2008-04-26T18:57:52Z",
+        "title": "Aleksi Eeben - The Four Tales [mtk201]"
+      },
+      {
+        "creator": "Left",
+        "downloads": 18251,
+        "identifier": "EMC23002Another_hour_of_EMCradio",
+        "licenseurl": "http://creativecommons.org/licenses/by-nc-nd/2.5/",
+        "mediatype": "audio",
+        "publicdate": "2006-07-23T18:34:38Z",
+        "subject": "EMCradio, compilation, independent, eclectic",
+        "title": "Another Hour of EMCradio"
+      },
+      {
+        "creator": "No Publicdate",
+        "downloads": 12,
+        "identifier": "item-without-a-publicdate",
+        "licenseurl": "http://creativecommons.org/licenses/by/4.0/",
+        "mediatype": "audio",
+        "subject": [
+          "jazz"
+        ],
+        "title": "Item without a publicdate"
+      },
+      {
+        "creator": "No Identifier",
+        "downloads": 34,
+        "licenseurl": "http://creativecommons.org/licenses/by/4.0/",
+        "mediatype": "audio",
+        "publicdate": "2019-02-11T10:00:00Z",
+        "subject": [
+          "jazz"
+        ],
+        "title": "Item without an identifier"
+      }
+    ]
+  }
+}

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchiveTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/apiservices/InternetArchiveTest.kt
@@ -51,6 +51,64 @@ class InternetArchiveTest {
         assertEquals(expectedResults, results)
     }
 
+    // The archive's metadata is supplied by uploaders, so fields the schema lists are
+    // routinely absent: a live query for "jazz" comes back with one item in fifty that
+    // carries no subject at all, and a handful whose subject is a bare string rather
+    // than a list. One of those cost us every search in production, because the mapping
+    // ran outside the try/catch and SearchEngine's coroutineScope propagated the throw
+    // to the other services.
+    @Test
+    fun testItSkipsItemsWithUnusableMetadataRatherThanFailingTheWholeSearch() = runBlocking {
+        val internetArchive = InternetArchive(ApiClientThatReadsFromFile("internetarchivewithoddmetadata"))
+        val results = internetArchive.search("test")
+
+        val expectedResults = listOf(
+            SearchResult(
+                author = "Natural Snow Buildings",
+                title = "Aldebaran [2016]",
+                duration = 0,
+                bpm = 0,
+                tags = "\"drone\", \"psychedelic\", \"folk\"",
+                date = LocalDate.parse("2016-07-14"),
+                externalLink = URI.create("https://archive.org/details/NaturalSnowBuildings-Aldebaran2016"),
+                license = CCLicense.CC_BY_NC_ND,
+                service = SearchService.INTERNETARCHIVE,
+                popularity = 2300
+            ),
+            // No subject: kept, with empty tags.
+            SearchResult(
+                author = "Aleksi Eeben",
+                title = "Aleksi Eeben - The Four Tales [mtk201]",
+                duration = 0,
+                bpm = 0,
+                tags = "",
+                date = LocalDate.parse("2008-04-26"),
+                externalLink = URI.create("https://archive.org/details/mtk201"),
+                license = CCLicense.CC_BY_NC_ND,
+                service = SearchService.INTERNETARCHIVE,
+                popularity = 6690
+            ),
+            // A bare string rather than a list of subjects: also kept, and the string is
+            // used as the tags rather than being dropped on the floor.
+            SearchResult(
+                author = "Left",
+                title = "Another Hour of EMCradio",
+                duration = 0,
+                bpm = 0,
+                tags = "EMCradio, compilation, independent, eclectic",
+                date = LocalDate.parse("2006-07-23"),
+                externalLink = URI.create("https://archive.org/details/EMC23002Another_hour_of_EMCradio"),
+                license = CCLicense.CC_BY_NC_ND,
+                service = SearchService.INTERNETARCHIVE,
+                popularity = 18251
+            )
+            // The last two docs in the fixture have no publicdate and no identifier
+            // respectively. Neither has a sensible stand-in, so they are dropped.
+        )
+
+        assertEquals(expectedResults, results)
+    }
+
     @Test
     fun testItReturnsAnEmptyListWhenTheClientThrowsAnException() = runBlocking {
         val internetArchive = InternetArchive(ApiClientThatThrows())


### PR DESCRIPTION
Fixes the production outage: every search has been returning a 500 since the ranking change went out.

```
java.lang.NullPointerException: get(...) must not be null
	at com.antodippo.ccmusicsearch.apiservices.InternetArchive.search$suspendImpl(InternetArchive.kt:60)
```

## What happened

Line 60 read the tags as `it["subject"].take(7)`. The archive's metadata is filled in by whoever uploaded the item, so `subject` is simply absent on roughly one item in fifty, and the platform-type null check threw.

That alone should have cost one item. Two things turned it into a total outage:

- the mapping ran **outside** `InternetArchive`'s `try`/`catch`, so a single bad doc failed the whole service;
- `SearchEngine` uses `coroutineScope`, so the throw cancelled every other service's search too.

A live query for `jazz` returns one item with no `subject`; `rock` returns two.

## The fix

**`InternetArchive`** maps each doc through `toSearchResult`, which returns `null` rather than throwing. Only `identifier` and `publicdate` have no sensible stand-in — nothing to link to without the first, and `SearchResult.date` is not nullable — so an item missing either is skipped, and every other field falls back. `publicdate` is now cut at the `T` rather than matched against a fixed pattern, the way `Freesound` already does it.

**`SearchEngine`** gets a per-service backstop, rethrowing `CancellationException` so structured concurrency still works. Each service already catches its own transport failures; this covers whatever gets past that.

## Behaviour change beyond the fix

A `subject` given as a bare string rather than a list now becomes the tags. It used to iterate as a node with no children and show nothing at all, which affects a few percent of items in every response. The list case is byte-identical to before.

## Verification

- The regression fixture uses two real items: `mtk201`, which has no `subject`, and `EMC23002Another_hour_of_EMCradio`, whose `subject` is a string. It reproduces the exact production NPE against the unfixed code.
- The `SearchEngine` isolation test also fails against the unfixed code — checked by reverting that file alone.
- Run live against archive.org: seven queries, 50 results each, no throw, nothing dropped.

## Follow-up, not in this PR

`Freesound` carries the identical `it["tags"].take(7)` plus several bare `.asText()` calls, and `CCMixter` indexes `it["files"][0][...]`. The `SearchEngine` backstop means these can no longer 500 the request, but one malformed doc still costs all of that service's results for the query. They want the same `mapNotNull` treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)