### PR TITLE
Report what a search actually returned, not just that one happened

### DIFF
--- a/src/main/resources/static/js/analytics.js
+++ b/src/main/resources/static/js/analytics.js
@@ -1,0 +1,71 @@
+/*
+ * Analytics reporting.
+ *
+ * Everything Google Analytics cannot work out on its own: what a search actually returned,
+ * which result was clicked, and what the filters are being asked for. Page views, engagement
+ * time and traffic sources need no help and are not repeated here.
+ *
+ * This is the only file that knows about gtag. The controls in search.js report through a
+ * 'ccms:track' event instead, and it lives apart from search.js because that file returns
+ * early when a search comes back empty — which is the case most worth measuring.
+ */
+(function () {
+    'use strict';
+
+    if (!window.ccmsAnalytics) {
+        return;
+    }
+
+    function send(name, params) {
+        gtag('event', name, params || {});
+    }
+
+    var app = document.querySelector('.app');
+    var page = app ? app.dataset : {};
+    var searchTerm = page.query || '';
+
+    /* ── the search itself ─────────────────────────────────────────────────── */
+
+    // GA4's own site search reports the term but not what came back, so a query that found
+    // nothing looks like any other. Counting the results is the whole point of sending this
+    // by hand; the built-in one is turned off in the property to avoid two rival datasets.
+    if (page.hasQuery === 'true') {
+        send('view_search_results', {
+            search_term: searchTerm,
+            result_count: Number(page.resultCount) || 0,
+            source_count: Number(page.sourceCount) || 0
+        });
+    }
+
+    /* ── clicking through to a service ─────────────────────────────────────── */
+
+    // Outbound clicks are already tracked, but only down to the domain. The rank and the
+    // licence are what say whether the ranking works and which licences people accept.
+    document.addEventListener('click', function (event) {
+        var link = event.target.closest ? event.target.closest('.row-listen') : null;
+        if (!link) return;
+
+        var row = link.closest('.row');
+        if (!row) return;
+
+        send('listen_click', {
+            service: row.dataset.service,
+            licence: row.dataset.licence,
+            position: row.dataset.position,
+            search_term: searchTerm
+        });
+    });
+
+    /* ── the rest of the page ──────────────────────────────────────────────── */
+
+    var themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+        themeToggle.addEventListener('click', function () {
+            send('theme_change', { theme: document.documentElement.getAttribute('data-theme') });
+        });
+    }
+
+    document.addEventListener('ccms:track', function (event) {
+        send(event.detail.name, event.detail.params);
+    });
+})();

--- a/src/main/resources/static/js/search.js
+++ b/src/main/resources/static/js/search.js
@@ -11,6 +11,15 @@
     var root = document.documentElement;
     var PAGE_SIZE = 25;
 
+    /*
+     * Reporting goes out as an event rather than a call, so this file never has to know
+     * whether anything is listening. analytics.js is the only thing that does. The names
+     * below are the ones GA4 wants, which saves translating them on the way out.
+     */
+    function track(name, params) {
+        document.dispatchEvent(new CustomEvent('ccms:track', { detail: { name: name, params: params } }));
+    }
+
     /* ── theme ─────────────────────────────────────────────────────────────── */
 
     var themeToggle = document.getElementById('theme-toggle');
@@ -128,6 +137,7 @@
             toggleIn(sources, key);
             button.setAttribute('aria-pressed', sources.has(key) ? 'true' : 'false');
             refilter();
+            track('filter_apply', { filter_type: 'source', filter_value: key });
         });
     });
 
@@ -139,6 +149,7 @@
             toggleIn(licences, key);
             button.setAttribute('aria-pressed', licences.has(key) ? 'true' : 'false');
             refilter();
+            track('filter_apply', { filter_type: 'licence', filter_value: key });
         });
     });
 
@@ -147,6 +158,7 @@
         commercialInput.addEventListener('change', function () {
             commercialOnly = commercialInput.checked;
             refilter();
+            track('filter_apply', { filter_type: 'commercial', filter_value: String(commercialOnly) });
         });
     }
 
@@ -160,6 +172,7 @@
             });
             reorder();
             refilter();
+            track('sort_change', { sort_by: sort });
         });
     });
 
@@ -167,6 +180,7 @@
         loadMore.addEventListener('click', function () {
             shown += PAGE_SIZE;
             apply();
+            track('load_more', { results_shown: shown });
         });
     }
 
@@ -187,6 +201,7 @@
         if (tempoRange) tempoRange.reset();
 
         refilter();
+        track('filter_reset', {});
     }
 
     function setAll(selector, text) {
@@ -205,6 +220,15 @@
         } else {
             set.add(key);
         }
+    }
+
+    function debounce(fn, wait) {
+        var timer = null;
+
+        return function () {
+            clearTimeout(timer);
+            timer = setTimeout(fn, wait);
+        };
     }
 
     /* ── two-handle range ──────────────────────────────────────────────────── */
@@ -242,16 +266,24 @@
             if (output) output.textContent = format(api.lo, api.hi);
         }
 
+        // A drag fires 'input' the whole way across, so the filtering keeps up live while
+        // the reporting waits for the handle to settle on a value worth recording.
+        var report = debounce(function () {
+            track('filter_apply', { filter_type: name, filter_value: api.lo + '-' + api.hi });
+        }, 500);
+
         // The handles share a track, so each one stops at the other rather than crossing.
         lo.addEventListener('input', function () {
             if (Number(lo.value) > Number(hi.value)) lo.value = hi.value;
             sync();
             refilter();
+            report();
         });
         hi.addEventListener('input', function () {
             if (Number(hi.value) < Number(lo.value)) hi.value = lo.value;
             sync();
             refilter();
+            report();
         });
 
         sync();

--- a/src/main/resources/templates/search.mustache
+++ b/src/main/resources/templates/search.mustache
@@ -27,7 +27,13 @@
 </head>
 <body>
 {{#page}}
-<div class="app">
+<!-- The attributes are what analytics.js reports; the browser decodes the entities Mustache
+     writes, which a value built into a script block would not. -->
+<div class="app"
+     data-query="{{q}}"
+     data-has-query="{{hasQuery}}"
+     data-result-count="{{resultCount}}"
+     data-source-count="{{sourceCount}}">
 
     <header class="topbar">
         <div class="topbar-inner">
@@ -320,17 +326,37 @@
 </div>
 {{/page}}
 
-<script src="/js/search.js" defer></script>
-
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-C4SRXZE7P4"></script>
+<!--
+  Google tag (gtag.js). Loaded only on the real site: the measurement ID is public, but a
+  local bootRun writing into the live property would skew the very numbers it reports.
+  Set ccms-analytics-debug in localStorage to switch it on anywhere for testing.
+-->
 <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
+    (function () {
+        var on = /(^|\.)ccmusicsearch\.com$/.test(location.hostname);
+        try {
+            on = on || !!localStorage.getItem('ccms-analytics-debug');
+        } catch (e) { /* private mode: no override, just the hostname test */ }
 
-    gtag('config', 'G-C4SRXZE7P4');
+        // analytics.js reads this, so it is set either way rather than left undefined on
+        // the branch that does not load the tag.
+        window.ccmsAnalytics = on;
+        if (!on) return;
+
+        var tag = document.createElement('script');
+        tag.async = true;
+        tag.src = 'https://www.googletagmanager.com/gtag/js?id=G-C4SRXZE7P4';
+        document.head.appendChild(tag);
+
+        window.dataLayer = window.dataLayer || [];
+        window.gtag = function () { dataLayer.push(arguments); };
+        gtag('js', new Date());
+        gtag('config', 'G-C4SRXZE7P4');
+    })();
 </script>
+
+<script src="/js/search.js" defer></script>
+<script src="/js/analytics.js" defer></script>
 
 </body>
 </html>


### PR DESCRIPTION
## What prompted this

The ticket asked to *add* analytics — but GA4 has been on the site since the "Version 1.0" commit (`24cfb4a`, tag `G-C4SRXZE7P4`) and is live on production right now. The `G-` prefix means GA4, not the Universal Analytics that Google shut down in 2023, so "is it still functioning?" is almost certainly yes — worth confirming in Realtime, but nothing needed installing.

So this PR does the work that was actually missing.

## Already free, left alone

Visitor counts, engagement time, and traffic sources need no help. Outbound click tracking already distinguishes jamendo.com / ccmixter.org / archive.org / freesound.org / icons8.com by domain. None of that is rebuilt here.

## What was missing

**Searches that return nothing.** GA4's built-in site search reports the term but not what came back, so a query finding zero results looks identical to one finding seventy-five. For a search engine that's the single most useful question, and it was unanswerable. `view_search_results` is now sent by hand with `result_count` and `source_count` attached.

**Everything the redesign added.** Filters, sort, and paging all run client-side over rows already in the document, so none of that use reached GA at all. Now `filter_apply`, `filter_reset`, `sort_change` and `load_more` report as they happen.

**Which result got clicked.** `listen_click` carries the service, licence and rank position alongside the query — none of which the built-in outbound tracking can express.

## The tag is now confined to production

The ID is hardcoded, so `bootRun` was writing into the live property and skewing the very numbers being read. The tag now loads only on `ccmusicsearch.com`; `localStorage.setItem('ccms-analytics-debug', '1')` switches it on anywhere for testing, so verifying needs no source edit to remember to revert.

## Two design notes

- The page's facts reach the browser as **data attributes**, not values built into a script block. Mustache escapes for HTML, and the browser decodes entities in attributes but *not* inside `<script>` — so a query containing a quote or ampersand arrives intact instead of as `&quot;`. Verified: `"jazz" & blues <script>` round-trips byte-identical, with no injection.
- `analytics.js` is a **separate file**, and `search.js` reports through a `ccms:track` custom event. That keeps gtag knowledge in one place — but the binding reason is that `search.js` returns early when there are no rows, which is exactly the zero-result case worth measuring.

## Verification

Driven against the dev server; events read off `dataLayer`, since the preview pane doesn't load the third-party script.

- Default localhost load → no flag, no `gtag`, no `dataLayer`, no tag script, zero requests to Google
- With the debug override → `view_search_results` with `search_term: "jazz"`, `result_count: 75`, `source_count: 2`
- Nonsense query → still fires, `result_count: 0` ✅
- All nine events fire with correct params: `listen_click` (service/licence/position/term), both `filter_apply` variants, `sort_change`, `load_more`, `theme_change`, `filter_reset`
- Range slider dragged end to end → 12 `input` events produce **one** debounced `filter_apply`
- `./gradlew test` green; `./gradlew pitest` at 69% against a threshold of 29
- No console errors

## Before this reports anything

Unregistered parameters are collected but never appear in reports. In GA4 admin:

1. **Register custom definitions** — metrics: `result_count`, `source_count`, `results_shown`; dimensions: `service`, `licence`, `filter_type`, `filter_value`, `sort_by`, `theme`, `position` (a dimension, not a metric — the useful question is how often rank 1 beats rank 10, which needs grouping)
2. **Turn off Enhanced Measurement → Site search**, or you get two rival search datasets. Leave outbound clicks on.
3. **Extend data retention** from the 2-month default to 14 months — this is about trends, and the default quietly discards them.

4. **After deploy, confirm on the wire in DebugView** — that `view_search_results` arrives carrying all three params, and that a zero-result search really records `result_count: 0`. The verification above reads `dataLayer`, which proves this code pushes the right arrays but not that gtag.js transforms them as expected; the library never loaded in the preview pane.

Note `listen_click` is a custom event name, so it lives in Explore / custom reports rather than a prebuilt one. That's the price of carrying licence and rank with it.

## Not in scope

No consent banner — GA4 sets cookies with no opt-in today, which this PR leaves exactly as it found it. Tracked as a separate draft issue on the project board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
