### PR TITLE
Say what each page is, and stop shipping it uncompressed

### DIFF
--- a/src/main/kotlin/com/antodippo/ccmusicsearch/SearchController.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/SearchController.kt
@@ -11,8 +11,13 @@ class SearchController(private val searchEngine: SearchEngine) {
     @GetMapping("/")
     suspend fun search(searchModel: Model, @RequestParam q: String?): String {
 
-        val songs = if (q != null) this.searchEngine.search(q) else emptyList()
-        searchModel["page"] = SearchPage.from(q, songs)
+        // A submitted-but-empty box is a first visit, not a search for nothing. Normalising
+        // here rather than at the call site keeps the two apart everywhere downstream: the
+        // page's hasQuery is what picks the welcome view over an empty workspace.
+        val query = q?.takeIf { it.isNotBlank() }
+
+        val songs = if (query != null) this.searchEngine.search(query) else emptyList()
+        searchModel["page"] = SearchPage.from(query, songs)
 
         return "search"
     }

--- a/src/main/kotlin/com/antodippo/ccmusicsearch/SearchPage.kt
+++ b/src/main/kotlin/com/antodippo/ccmusicsearch/SearchPage.kt
@@ -19,6 +19,8 @@ data class SearchPage(
     val resultNoun: String,
     val sourceCount: Int,
     val sourceNoun: String,
+    val pageTitle: String,
+    val metaDescription: String,
     val results: List<SongView>,
     val facets: List<FacetView>,
     val licences: List<LicenceView>,
@@ -30,21 +32,61 @@ data class SearchPage(
         fun from(query: String?, results: List<SearchResult>): SearchPage {
             val songs = results.mapIndexed { index, result -> SongView.of(result, index) }
             val sourceCount = results.map { it.service }.distinct().size
+            val resultNoun = plural(songs.size, "result")
+            val sourceNoun = plural(sourceCount, "source")
 
             return SearchPage(
                 q = query.orEmpty(),
                 hasQuery = query != null,
                 hasResults = songs.isNotEmpty(),
                 resultCount = songs.size,
-                resultNoun = plural(songs.size, "result"),
+                resultNoun = resultNoun,
                 sourceCount = sourceCount,
-                sourceNoun = plural(sourceCount, "source"),
+                sourceNoun = sourceNoun,
+                pageTitle = pageTitle(query, songs.size),
+                metaDescription = metaDescription(query, songs.size, resultNoun, sourceCount, sourceNoun),
                 results = songs,
                 facets = facets(results),
                 licences = licences(results),
                 length = lengthRange(results),
                 tempo = tempoRange(results),
             )
+        }
+
+        /**
+         * The landing page leads with "Free … Music Search" because that is the phrase people
+         * type; "Creative Commons" qualifies it rather than leading. Calling any of this
+         * "royalty-free" would be untrue — half the catalogue is NC-licensed — and a title that
+         * oversells buys a click and loses the visitor.
+         *
+         * Search pages carry noindex, so their title is for the tab and for shared links.
+         */
+        private fun pageTitle(query: String?, resultCount: Int): String = when {
+            query == null -> "Free Creative Commons Music Search — CCMusic Search"
+            resultCount == 0 -> "No Creative Commons music found for “$query”"
+            else -> "“$query” — free Creative Commons music"
+        }
+
+        private fun metaDescription(
+            query: String?,
+            resultCount: Int,
+            resultNoun: String,
+            sourceCount: Int,
+            sourceNoun: String,
+        ): String = when {
+            query == null ->
+                "Search Jamendo, ccMixter, Icons8, Internet Archive and Freesound at once for " +
+                    "free, Creative Commons-licensed music for videos, podcasts and streams. " +
+                    "Filter by licence, length and BPM."
+
+            resultCount == 0 ->
+                "No Creative Commons music matched “$query”. Try a different word, an artist " +
+                    "name, or a mood."
+
+            else ->
+                "$resultCount Creative Commons $resultNoun for “$query” across $sourceCount " +
+                    "$sourceNoun. Filter by licence, length and BPM, and check what each track " +
+                    "allows before you use it."
         }
 
         /** Every service is listed whether or not it answered, so the rail keeps its shape. */

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,12 @@
+# A results page is a few hundred kB of HTML — one row per track, every one of them
+# carrying its raw values as data attributes for the client-side filters. Uncompressed
+# that is the single largest thing the site sends.
+server.compression.enabled=true
+server.compression.mime-types=text/html,text/css,text/plain,text/xml,application/javascript,application/json,image/svg+xml
+server.compression.min-response-size=1024
 
+# Asset URLs are not content-hashed, so a long max-age would leave returning visitors on
+# a stale stylesheet after a deploy. A day, with the last-modified revalidation the
+# resource handler already sends, is the balance.
+spring.web.resources.cache.cachecontrol.max-age=1d
+spring.web.resources.cache.cachecontrol.cache-public=true

--- a/src/main/resources/static/ds/styles.css
+++ b/src/main/resources/static/ds/styles.css
@@ -1,5 +1,7 @@
 /* Organic — design-system tokens and component classes. This file is the source of truth for the system's look; retune it here and see readme.md. */
-@import url('https://fonts.googleapis.com/css2?family=Caprasimo:wght@400&family=Figtree:wght@400;600;700&display=swap');
+/* The webfonts are requested by a <link> in the document head, not @import-ed here: an
+   @import cannot start until this file has been fetched and parsed, which costs the fonts
+   an extra round trip on every first paint. */
 
 :root {
   --color-bg: #f5ead8;
@@ -71,6 +73,21 @@ body {
 h1, h2, h3, h4 { font-family: var(--font-heading); font-weight: var(--font-heading-weight); }
 
 .washed{filter:saturate(0.6) contrast(0.85) brightness(1.1) opacity(0.94)}
+
+/* Present to a screen reader, absent to the eye — for the heading a page owes its
+   structure but whose design already says the same thing visually. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
 
 /* ══════════════════════════════════════════════════════════════════════════
    Components — built with the tokens above. Plain CSS

--- a/src/main/resources/static/robots.txt
+++ b/src/main/resources/static/robots.txt
@@ -1,0 +1,8 @@
+# Search pages (/?q=…) are deliberately not disallowed here. They carry a noindex meta tag,
+# and a crawler that is told not to fetch a URL never reads the tag telling it not to index —
+# so a Disallow would be the one thing that keeps them in the index.
+
+User-agent: *
+Allow: /
+
+Sitemap: https://ccmusicsearch.com/sitemap.xml

--- a/src/main/resources/static/sitemap.xml
+++ b/src/main/resources/static/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  One entry, because the site is one page. Search pages are noindex and belong nowhere near
+  a sitemap; listing URLs we are asking not to be indexed would be a contradiction.
+-->
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://ccmusicsearch.com/</loc>
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+    </url>
+</urlset>

--- a/src/main/resources/templates/about.mustache
+++ b/src/main/resources/templates/about.mustache
@@ -1,10 +1,10 @@
 <div class="about">
     <p>
         CCMusic Search is a simple search engine for
-        <a href="http://creativecommons.org/about" target="_blank" rel="noopener">Creative Commons</a> music.
+        <a href="https://creativecommons.org/about" target="_blank" rel="noopener">Creative Commons</a> music.
         It uses public APIs to find music released under CC on
         <a href="https://www.jamendo.com/" target="_blank" rel="noopener">Jamendo</a>,
-        <a href="http://ccmixter.org/" target="_blank" rel="noopener">ccMixter</a>,
+        <a href="https://ccmixter.org/" target="_blank" rel="noopener">ccMixter</a>,
         <a href="https://icons8.com/music" target="_blank" rel="noopener">Icons8</a>,
         <a href="https://archive.org/" target="_blank" rel="noopener">Internet Archive</a> and
         <a href="https://freesound.org/" target="_blank" rel="noopener">Freesound</a>.
@@ -13,12 +13,12 @@
     </p>
     <div class="about-licence">
         <a class="about-badge" rel="license noopener" target="_blank"
-           href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA</a>
+           href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA</a>
         <div>
             Except where noted, content on this site is licensed under
             <a rel="license noopener" target="_blank"
-               href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a> —
-            <a href="http://antodippo.com" target="_blank" rel="noopener">Antonello D'Ippolito</a>, 2023
+               href="https://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY-NC-SA 4.0</a> —
+            <a href="https://antodippo.com" target="_blank" rel="noopener">Antonello D'Ippolito</a>, 2023
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/search.mustache
+++ b/src/main/resources/templates/search.mustache
@@ -3,13 +3,68 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>CCMusic search</title>
-    <meta name="description" content="A search engine for Creative Commons music.">
+
+    {{#page}}
+    <title>{{pageTitle}}</title>
+    <meta name="description" content="{{metaDescription}}">
+
+    <!--
+      A search page is an internal result listing: useful to the visitor who ran it, thin and
+      duplicative in an index. It is kept out with noindex rather than a robots.txt Disallow,
+      because a disallowed URL is never fetched and the tag below would never be read.
+
+      Only the landing page declares a canonical. It is what folds www and the raw Cloud Run
+      hostname back into one URL. Pointing a noindex page at a different canonical would be two
+      instructions that contradict each other, so the search pages declare none.
+    -->
+    {{#hasQuery}}
+    <meta name="robots" content="noindex, follow">
+    {{/hasQuery}}
+    {{^hasQuery}}
+    <link rel="canonical" href="https://ccmusicsearch.com/">
+    {{/hasQuery}}
+
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="CCMusic Search">
+    <meta property="og:title" content="{{pageTitle}}">
+    <meta property="og:description" content="{{metaDescription}}">
+    <!-- Declared only where it is the canonical URL. On a search page it would point the
+         share card away from the search that was actually shared. -->
+    {{^hasQuery}}
+    <meta property="og:url" content="https://ccmusicsearch.com/">
+    {{/hasQuery}}
+    <meta name="twitter:card" content="summary">
+    {{/page}}
+
     <link rel="icon" type="image/x-icon" href="/favicon.ico">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <!-- Requested here rather than @import-ed from styles.css: an @import is only discovered
+         once that stylesheet has been fetched and parsed, which puts the fonts a whole round
+         trip further back and leaves the preconnects above with nothing to warm up. -->
+    <link rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Caprasimo:wght@400&family=Figtree:wght@400;600;700&display=swap">
     <link rel="stylesheet" href="/ds/styles.css">
     <link rel="stylesheet" href="/css/search.css">
+
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "WebSite",
+            "name": "CCMusic Search",
+            "url": "https://ccmusicsearch.com/",
+            "description": "A search engine for Creative Commons music, covering Jamendo, ccMixter, Icons8, Internet Archive and Freesound.",
+            "inLanguage": "en",
+            "potentialAction": {
+                "@type": "SearchAction",
+                "target": {
+                    "@type": "EntryPoint",
+                    "urlTemplate": "https://ccmusicsearch.com/?q={search_term_string}"
+                },
+                "query-input": "required name=search_term_string"
+            }
+        }
+    </script>
     <script>
         // Runs before first paint: a dark-theme reload must not flash the light ground.
         // Setting data-js here is also what reveals the controls that need scripting.
@@ -196,6 +251,11 @@
         </aside>
 
         <main class="results scroller">
+            <!-- The count line below reads as the heading and is the live region, so it cannot
+                 also be the h1. This gives the page the one heading it owes assistive tech
+                 without a second visible title above the results. -->
+            <h1 class="visually-hidden">Creative Commons music matching “{{q}}”</h1>
+
             <div class="results-head">
                 <div class="results-summary">
                     <p class="results-count" id="results-count" aria-live="polite">
@@ -311,9 +371,9 @@
     {{^hasQuery}}
     <main class="welcome">
         <div class="disc welcome-disc"><span class="disc-label disc-1"></span></div>
-        <h1>CCMusic Search</h1>
-        <p class="welcome-lead">A search engine for Creative Commons music. Search once, and get results from five
-            catalogues at the same time.</p>
+        <h1>Search free Creative Commons music</h1>
+        <p class="welcome-lead">Search once, and get results from five catalogues at the same time — music you can
+            use in videos, podcasts and streams, with every track's licence shown up front.</p>
         <div class="welcome-sources">
             {{#facets}}
             <span class="chip-service"><span class="dot dot-{{key}}"></span>{{label}}</span>

--- a/src/test/kotlin/com/antodippo/ccmusicsearch/SearchPageTest.kt
+++ b/src/test/kotlin/com/antodippo/ccmusicsearch/SearchPageTest.kt
@@ -49,6 +49,51 @@ class SearchPageTest {
     }
 
     @Test
+    fun testItTitlesEachOfTheThreeThingsThePageCanBe() {
+        // The landing page is the only one search engines index, so it is the only one whose
+        // title has to carry what the site is rather than what was typed.
+        assertEquals(
+            "Free Creative Commons Music Search — CCMusic Search",
+            SearchPage.from(null, emptyList()).pageTitle
+        )
+        assertEquals(
+            "No Creative Commons music found for “jazz”",
+            SearchPage.from("jazz", emptyList()).pageTitle
+        )
+        assertEquals("“jazz” — free Creative Commons music", pageOf(result()).pageTitle)
+    }
+
+    @Test
+    fun testItDescribesWhatTheSearchActuallyFound() {
+        val page = SearchPage.from(
+            "jazz",
+            listOf(result(service = SearchService.JAMENDO), result(service = SearchService.CCMIXTER))
+        )
+
+        assertEquals(
+            "2 Creative Commons results for “jazz” across 2 sources. Filter by licence, length " +
+                "and BPM, and check what each track allows before you use it.",
+            page.metaDescription
+        )
+
+        // Singular reads as badly in a description as it does on the page itself.
+        assertTrue(pageOf(result()).metaDescription.startsWith("1 Creative Commons result for"))
+
+        assertTrue(SearchPage.from(null, emptyList()).metaDescription.startsWith("Search Jamendo,"))
+        assertTrue(SearchPage.from("jazz", emptyList()).metaDescription.startsWith("No Creative Commons music matched"))
+    }
+
+    @Test
+    fun testItPutsTheQueryIntoTheTitleWithoutInterpretingIt() {
+        // These land in a <title> and in a content="…" attribute. Mustache escapes on the way
+        // out, so what is stored is the raw query — the escaping is not this class's job, and
+        // double-escaping here would show up as &amp;quot; on the page.
+        val page = SearchPage.from("\"><script>", emptyList())
+
+        assertEquals("No Creative Commons music found for “\"><script>”", page.pageTitle)
+    }
+
+    @Test
     fun testItFormatsDurationsAsMinutesAndSeconds() {
         assertEquals("4:52", songOf(result(duration = 292)).durationLabel)
         assertEquals("0:07", songOf(result(duration = 7)).durationLabel)


### PR DESCRIPTION
Technical SEO pass over the site. No visual redesign — one copy change on the landing page, everything else is head tags, headers, and two new static files.

## What was wrong

Verified live against ccmusicsearch.com before touching anything:

| | |
|---|---|
| **Nothing was compressed** | `application.properties` was empty, so `server.compression` was never switched on |
| Static `<title>` and description | `CCMusic search` on every URL — landing page and every search alike |
| No canonical | apex and `www` both returned `200` with byte-identical bodies |
| `/robots.txt`, `/sitemap.xml` | both 404 |
| Search pages indexable | no `robots` meta anywhere |
| No `Cache-Control` on assets | 51 kB of CSS/JS revalidated every visit |
| No Open Graph tags | shared links render as bare URLs |
| Webfonts via CSS `@import` | HTML → styles.css → fonts CSS → font files, and the two `preconnect`s had nothing to warm up |
| Search pages had no `<h1>` | the only one was the brand string on the landing page |
| `/?q=` (empty) | `200`, five API calls, 239 kB of results nobody asked for |

## What changed

**Compression** is the big one — a `?q=piano` page goes from **240,701 → 14,956 bytes**, measured on `bootRun`. Assets get `max-age=1d`, deliberately short: their URLs are not content-hashed, so a long TTL would leave returning visitors on a stale stylesheet after a deploy.

**Titles and descriptions** are computed in `SearchPage.from()`, alongside the labels and counts the class already decides. Three branches — landing, results, no results — and the results one reuses the existing `resultCount`/`sourceNoun` fields rather than recounting.

**Indexing.** Search pages get `noindex, follow`; only the landing page declares a canonical. `robots.txt` deliberately does *not* `Disallow: /*?q=` — a disallowed URL is never fetched, so the noindex would never be read, and the URLs would stay in the index as bare entries. That reasoning is in the file so it does not get "fixed" later.

**On the title wording:** it leads with `Free Creative Commons Music Search`. "Royalty-free" and "copyright-free" have more search demand but would be false here — half the catalogue is NC-licensed — and a title that oversells buys a click and loses the visitor. The adjacent intent is captured honestly in the description and the landing copy instead.

Also: `<h1>`s on both views (visually hidden on results, since the count line is already the visible heading and the live region), `WebSite` JSON-LD, `og:`/`twitter:` tags, `/?q=` renders the welcome view, webfonts via `<link>`, and the `http://` outbound links in `about.mustache` upgraded to `https://` — all four verified to support it.

## Verification

`./gradlew test` green, including four new `SearchPageTest` cases covering the title/description branches and that a query with HTML-special characters is stored raw for Mustache to escape on the way out.

On `bootRun`: `content-encoding: gzip` and `vary: accept-encoding` present; `Cache-Control: max-age=86400, public` on assets; robots and sitemap serve; landing page has canonical and no robots meta, `?q=jazz` has `noindex, follow` and no canonical; JSON-LD parses and `{search_term_string}` survives Mustache untouched. In the browser: both webfonts load, no `@import` rule remains, exactly one `h1` per page, and the new landing heading fits one line at desktop and wraps to two cleanly at 375px.

## Not in this PR

An `og-image.png` — `twitter:card=summary` works without one, so the tags ship now and the image is a small follow-up. Two items are infrastructure rather than code: a **301 `www` → apex** at the Cloud Run domain mapping (the canonical covers it, a redirect is stronger), and **Search Console verification**, which needs the account holder.

**Worth saying plainly:** none of this will move visitor numbers much. The site has exactly one indexable URL and already ranks for its own name. This makes that page correct and fast; volume needs pages that answer what people actually search for — licence explainers, "can I use this on YouTube", per-source guides — which is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)